### PR TITLE
Add media folder to umbraco.gitignore

### DIFF
--- a/Umbraco.gitignore
+++ b/Umbraco.gitignore
@@ -19,6 +19,10 @@
 ## Uncomment this line if you think it fits the way you work on your project.
 ## **/[Uu]mbraco/ 
 
+## This [Mm]edia/ folder contains content. Content may vary by environment and should therefore not be added to source control.
+## Uncomment this line if you think it fits the way you work on your project.
+## **/[Mm]edia/ 
+
 # Don't ignore Umbraco packages (VisualStudio.gitignore mistakes this for a NuGet packages folder)
 # Make sure to include details from VisualStudio.gitignore BEFORE this
 !**/App_Data/[Pp]ackages/*


### PR DESCRIPTION
**Reasons for making this change:**

Excluding the media folder is best practice.

**Links to documentation supporting these rule changes:**

https://our.umbraco.com/Documentation/Fundamentals/Code/Source-Control/#media
